### PR TITLE
Feat/jetson tx2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ include(cmake/ccache.cmake)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Ofast -DNDEBUG -Wno-deprecated-declarations")
 
+# Adding experimental/filesystem
+set(CXX_FILESYSTEM_LIBRARIES stdc++fs ${CXX_FILESYSTEM_LIBRARIES})
+
 # For finding FindTensorRT.cmake
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -23,7 +26,7 @@ add_library(tensorrt_cpp_api SHARED
         src/engine.cpp)
 
 target_include_directories(tensorrt_cpp_api PUBLIC ${OpenCV_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS} ${TensorRT_INCLUDE_DIRS})
-target_link_libraries(tensorrt_cpp_api PUBLIC ${OpenCV_LIBS} ${CUDA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${TensorRT_LIBRARIES})
+target_link_libraries(tensorrt_cpp_api PUBLIC ${CXX_FILESYSTEM_LIBRARIES} ${OpenCV_LIBS} ${CUDA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${TensorRT_LIBRARIES})
 
 add_executable(run_inference_benchmark src/main.cpp)
 target_link_libraries(run_inference_benchmark tensorrt_cpp_api)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Benchmarks run on Jetson-TX2 p3310-1000.
 | Model   | Precision | Batch Size | Avg Inference Time |
 |---------|-----------|------------|--------------------|
 | yolov8n | FP16      | 1          | 37.258 ms          |
+| yolov8m | FP16      | 1          | 123.685 ms         |
+| yolov8x | FP16      | 1          | 297.166 ms         |
 
 ### Sample Integration
 Wondering how to integrate this library into your project? Or perhaps how to read the outputs of the YoloV8 model to extract meaningful information? 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <fstream>
+#include <experimental/filesystem>
 #include <iostream>
 #include <random>
 #include <iterator>
@@ -9,6 +10,14 @@
 
 using namespace nvinfer1;
 using namespace Util;
+
+std::vector<std::string> Util::getFilesInDirectory(const std::string& dirPath) {
+    std::vector<std::string> filepaths;
+    for (const auto& entry: std::experimental::filesystem::directory_iterator(dirPath)) {
+        filepaths.emplace_back(entry.path());
+    }
+    return filepaths;
+}
 
 void Logger::log(Severity severity, const char *msg) noexcept {
     // Would advise using a proper logging utility such as https://github.com/gabime/spdlog
@@ -521,7 +530,7 @@ Int8EntropyCalibrator2::Int8EntropyCalibrator2(int32_t batchSize, int32_t inputW
         throw std::runtime_error("Error, directory at provided path does not exist: " + calibDataDirPath);
     }
 
-    m_imgPaths.push_back("");
+    m_imgPaths = getFilesInDirectory(calibDataDirPath);
     if (m_imgPaths.size() < static_cast<size_t>(batchSize)) {
         throw std::runtime_error("There are fewer calibration images than the specified batch size!");
     }

--- a/src/engine.h
+++ b/src/engine.h
@@ -22,6 +22,8 @@ namespace Util {
             throw std::runtime_error(errMsg);
         }
     }
+
+    std::vector<std::string> getFilesInDirectory(const std::string& dirPath);
 }
 // Utility Timer
 template <typename Clock = std::chrono::high_resolution_clock>


### PR DESCRIPTION
Hi,

This PR adds the following:
* Re-enables INT8 inference (using `experimental/filesystem` for C++14 compatibility)
* Adds benchmarks for `yolov8m` and `yolov8x`. INT8 precision will follow.

Since you are not using a lot of the C++17 features, I would suggest you to retro-back to C++14 also in `main` (for better system compatibility with users), as you want.

Still working on dynamic tensor inputs on the old TensorRT API.

Thanks,
