### PR TITLE
Original function:

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -81,7 +81,7 @@ bool Int8EntropyCalibrator2::getBatch(void **bindings, const char **names, int32
 
         cv::cuda::GpuMat gpuImg;
         gpuImg.upload(cpuImg);
-        cv::cuda::cvtColor(gpuImg, gpuImg, cv::COLOR_BGR2RGB);
+        //cv::cuda::cvtColor(gpuImg, gpuImg, cv::COLOR_BGR2RGB);
 
         // TODO: Define any preprocessing code here, such as resizing
         auto resized = Engine<float>::resizeKeepAspectRatioPadRightBottom(gpuImg, m_inputH, m_inputW);
@@ -91,7 +91,7 @@ bool Int8EntropyCalibrator2::getBatch(void **bindings, const char **names, int32
 
     // Convert the batch from NHWC to NCHW
     // ALso apply normalization, scaling, and mean subtraction
-    auto mfloat = Engine<float>::blobFromGpuMats(inputImgs, m_subVals, m_divVals, m_normalize);
+    auto mfloat = Engine<float>::blobFromGpuMats(inputImgs, m_subVals, m_divVals, m_normalize, true);
     auto *dataPointer = mfloat.ptr<void>();
 
     // Copy the GPU buffer to member variable so that it persists

--- a/src/engine.h
+++ b/src/engine.h
@@ -12,6 +12,16 @@
 #include <opencv2/cudawarping.hpp>
 #include <opencv2/opencv.hpp>
 
+
+#define CHECK(condition)                                                                                                                   \
+    do {                                                                                                                                   \
+        if (!(condition)) {                                                                                                                \
+            std::cerr << "Assertion failed: (" << #condition << "), function " << __FUNCTION__ << ", file " << __FILE__ << ", line "       \
+                      << __LINE__ << "." << std::endl;                                                                                     \
+            abort();                                                                                                                       \
+        }                                                                                                                                  \
+    } while (false);
+
 // Utility methods
 namespace Util {
 inline bool doesFileExist(const std::string &filepath) {
@@ -171,7 +181,7 @@ public:
     static void transformOutput(std::vector<std::vector<std::vector<T>>> &input, std::vector<T> &output);
     // Convert NHWC to NCHW and apply scaling and mean subtraction
     static cv::cuda::GpuMat blobFromGpuMats(const std::vector<cv::cuda::GpuMat> &batchInput, const std::array<float, 3> &subVals,
-                                            const std::array<float, 3> &divVals, bool normalize);
+                                            const std::array<float, 3> &divVals, bool normalize, bool swapRB = false);
 
 private:
     // Build the network
@@ -682,18 +692,31 @@ bool Engine<T>::runInference(const std::vector<std::vector<cv::cuda::GpuMat>> &i
 
 template <typename T>
 cv::cuda::GpuMat Engine<T>::blobFromGpuMats(const std::vector<cv::cuda::GpuMat> &batchInput, const std::array<float, 3> &subVals,
-                                            const std::array<float, 3> &divVals, bool normalize) {
+                                            const std::array<float, 3> &divVals, bool normalize, bool swapRB) {
+   
+    CHECK(!batchInput.empty())
+    CHECK(batchInput[0].channels() == 3)
+    
     cv::cuda::GpuMat gpu_dst(1, batchInput[0].rows * batchInput[0].cols * batchInput.size(), CV_8UC3);
 
     size_t width = batchInput[0].cols * batchInput[0].rows;
-    for (size_t img = 0; img < batchInput.size(); img++) {
-        std::vector<cv::cuda::GpuMat> input_channels{
-            cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[0 + width * 3 * img])),
-            cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[width + width * 3 * img])),
-            cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[width * 2 + width * 3 * img]))};
-        cv::cuda::split(batchInput[img], input_channels); // HWC -> CHW
+    if (swapRB) {
+        for (size_t img = 0; img < batchInput.size(); ++img) {
+            std::vector<cv::cuda::GpuMat> input_channels{
+                cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[width * 2 + width * 3 * img])),
+                cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[width + width * 3 * img])),
+                cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[0 + width * 3 * img]))};
+            cv::cuda::split(batchInput[img], input_channels); // HWC -> CHW
+        }
+    } else {
+        for (size_t img = 0; img < batchInput.size(); ++img) {
+            std::vector<cv::cuda::GpuMat> input_channels{
+                cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[0 + width * 3 * img])),
+                cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[width + width * 3 * img])),
+                cv::cuda::GpuMat(batchInput[0].rows, batchInput[0].cols, CV_8U, &(gpu_dst.ptr()[width * 2 + width * 3 * img]))};
+            cv::cuda::split(batchInput[img], input_channels); // HWC -> CHW
+        }
     }
-
     cv::cuda::GpuMat mfloat;
     if (normalize) {
         // [0.f, 1.f]


### PR DESCRIPTION
```cpp
static cv::cuda::GpuMat blobFromGpuMats(const std::vector<cv::cuda::GpuMat> &batchInput, const std::array<float, 3> &subVals,
                                        const std::array<float, 3> &divVals, bool normalize);
```

Modified function:
```cpp
static cv::cuda::GpuMat blobFromGpuMats(const std::vector<cv::cuda::GpuMat> &batchInput, const std::array<float, 3> &subVals,
                                        const std::array<float, 3> &divVals, bool normalize, bool swapRB = false);
```

In this modification, an additional parameter `swapRB` of type `bool` with a default value of `false` is added to the function signature. This parameter is used to specify whether the Red and Blue channels should be swapped during processing.