### PR TITLE
Add an optional `engineDir` parameter to the `buildLoadNetwork` function

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -250,7 +250,7 @@ bool Engine<T>::buildLoadNetwork(std::string onnxModelPath, const std::array<flo
     }
 
     // Load the TensorRT engine file into memory
-    return loadNetwork(engineName, subVals, divVals, normalize);
+    return loadNetwork(enginePath.string(), subVals, divVals, normalize);
 }
 
 template <typename T>


### PR DESCRIPTION
Closes #61 

**Description**:
This PR adds an optional `engineDir` parameter to the `buildLoadNetwork` function. This parameter allows users to specify the directory where `.engine` models are stored.

**Changes**:
- Added `engineDir` parameter to `buildLoadNetwork`.
- Updated the function to store/load the engine file from the specified directory.